### PR TITLE
Fix getTables to show the query error if a query error occurs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ module.exports = function(options,done){
 		getTables:function(callback){
 			if(!options.tables || !options.tables.length){ // if not especifed, get all
 				mysql.query("SHOW TABLES FROM `"+options.database+"`",function(err,data){
+					if(err) return callback(err);
 					var resp = [];
 					for(var i=0;i<data.length;i++) resp.push(data[i]['Tables_in_'+options.database]);
 					callback(err,resp);


### PR DESCRIPTION
Hey webcaetano — Thanks for writing this package. One thing I noticed: If there is a query error, a callback with the error should execute immediately; code that operates on the expected results of the query should _not_ run, or the error that will ultimately be thrown will be cryptic. For example, I made the stupid mistake of putting in the wrong host info, and I got this error originally:

`TypeError: Cannot read property 'length' of undefined`

After the change in this PR, this is the error I get:

`Error: Error: connect ECONNREFUSED 127.0.0.1:3307`

The latter provides a better hint that my connection info is wrong.
