### PR TITLE
Handle Dump Instead of Writing a File

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,11 +145,6 @@ module.exports = function(options,done){
 			});
 			async.parallel(run,callback)
 		}],
-		createFile:['createSchemaDump','createDataDump',function(callback,results){
-			if(!results.createSchemaDump || !results.createSchemaDump.length) results.createSchemaDump=[];
-			if(!results.createDataDump || !results.createDataDump.length) results.createDataDump=[];
-			fs.writeFile(options.dest, results.createSchemaDump.concat(results.createDataDump).join("\n\n"), callback);
-		}],
 		getDataDump:['createSchemaDump','createDataDump',function(callback,results){
 			if(!results.createSchemaDump || !results.createSchemaDump.length) results.createSchemaDump=[];
 			if(!results.createDataDump || !results.createDataDump.length) results.createDataDump=[];
@@ -159,6 +154,7 @@ module.exports = function(options,done){
 		if(err) throw new Error(err);
 
 		console.timeEnd('mysql dump');
-		done(err,(options.getDump ? results.getDataDump : results.createFile));
+		if(options.getDump) return done(err, results.getDataDump);
+		fs.writeFile(options.dest, results.getDataDump, done);
 	});
 }

--- a/index.js
+++ b/index.js
@@ -149,10 +149,16 @@ module.exports = function(options,done){
 			if(!results.createSchemaDump || !results.createSchemaDump.length) results.createSchemaDump=[];
 			if(!results.createDataDump || !results.createDataDump.length) results.createDataDump=[];
 			fs.writeFile(options.dest, results.createSchemaDump.concat(results.createDataDump).join("\n\n"), callback);
+		}],
+		getDataDump:['createSchemaDump','createDataDump',function(callback,results){
+			if(!results.createSchemaDump || !results.createSchemaDump.length) results.createSchemaDump=[];
+			if(!results.createDataDump || !results.createDataDump.length) results.createDataDump=[];
+			callback(null,results.createSchemaDump.concat(results.createDataDump).join("\n\n"));
 		}]
 	},function(err,results){
 		if(err) throw new Error(err);
+
 		console.timeEnd('mysql dump');
-		done(err,results.createFile);
+		done(err,(options.getDump ? results.getDataDump : results.createFile));
 	});
 }


### PR DESCRIPTION
Setting `options.getDump` intercepts writing content to `options.dest` and sends mysqldump content to callback supplied.

Eg. 

``` js
require('mysqldump')({
  host: 'localhost',
  database: 'sample_db',
  getDump: true
}, function( error, dump ){
  if( error ) throw error;
  console.log( dump );
  // todo: send dump as email
});
```
