### PR TITLE
improve MySQL exception handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = function(options,done){
 				})
 			})
 			async.parallel(run,function(err,data){
-				if (err) return callback(err)
+				if (err) return callback(err);
 				var resp = [];
 				for(var i in data){
 					var r = data[i][0]['Create Table']+";";
@@ -152,7 +152,7 @@ module.exports = function(options,done){
 						opts.where = options.where[table];
 					}
 					mysql.select(opts,function(err,data){
-						if (err) return callback(err)
+						if (err) return callback(err);
 						callback(err,buildInsert(data,table));
 					});
 				});
@@ -165,7 +165,7 @@ module.exports = function(options,done){
 			callback(null,results.createSchemaDump.concat(results.createDataDump).join("\n\n"));
 		}]
 	},function(err,results){
-		if(err) return done(err)
+		if(err) return done(err);
 
 		mysql.connection.end();
 		if(options.getDump) return done(err, results.getDataDump);

--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ module.exports = function(options,done){
 				})
 			})
 			async.parallel(run,function(err,data){
+				if (err) return callback(err)
 				var resp = [];
 				for(var i in data){
 					var r = data[i][0]['Create Table']+";";
@@ -151,6 +152,7 @@ module.exports = function(options,done){
 						opts.where = options.where[table];
 					}
 					mysql.select(opts,function(err,data){
+						if (err) return callback(err)
 						callback(err,buildInsert(data,table));
 					});
 				});
@@ -163,7 +165,7 @@ module.exports = function(options,done){
 			callback(null,results.createSchemaDump.concat(results.createDataDump).join("\n\n"));
 		}]
 	},function(err,results){
-		if(err) throw new Error(err);
+		if(err) return done(err)
 
 		mysql.connection.end();
 		if(options.getDump) return done(err, results.getDataDump);


### PR DESCRIPTION
Hello. 

I have encountered some difficulties dealing with exceptions originating from MySQL calls.
In my database setup, different users are granted different sets of privileges, and its entirely possible that calls to SELECT, SHOW TABLES, etc. will throw unexpectedly. These throws do not get correctly propagated to the mysqldump caller, cannot be caught and crash the whole application.    

Luckily, this can be easily fixed with a few defensive checks:

1. An ‘async.parallel’ callback within ‘createSchemaDump’ may return an error object. If ignored, an undefined ‘data’ object will crash the loop that follows.
2. A ‘mysql.select’ callback within ‘createDataDump’ may return an error object. If ignored, a possibly undefined data object will be passed to the ‘buildInsert’ call.
3. The main ‘async.auto’ callback rethrows the callback’s error object. To my knowledge, there is no way for the external caller to catch this throw and gracefully deal with the original exception. Instead the whole thread will crash. 

The changes are basically three one-liners. Some additional complexity comes from implementation of additional unit tests. 

Best regards