### PR TITLE
Added option to set connection charset

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,8 @@ module.exports = function(options,done){
 		host: 'localhost',
 		user: 'root',
 		password: '',
-		database: 'test'
+		database: 'test',
+		charset: 'UTF8_GENERAL_CI',
 	};
 
 	var defaultOptions = {
@@ -146,6 +147,7 @@ module.exports = function(options,done){
 		password:options.password,
 		database:options.database,
 		port:options.port,
+		charset:options.charset,
 		socketPath:options.socketPath,
 	}));
 


### PR DESCRIPTION
Simply adds the option to specify a charset for the MySQL-connection.

If no charset is specified, it simply defaults to the node-mysql default.