### PR TITLE
dump without writing a file

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = function(options,done){
 		autoIncrement:true,
 		dropTable:false,
 		getDump:false,
-		dest:'./data.sql',
+		// dest:'./data.sql',
 		where: null
 	}
 
@@ -227,6 +227,8 @@ module.exports = function(options,done){
 
 		mysql.connection.end();
 		if(options.getDump) return done(err, results.getDataDump);
-		fs.writeFile(options.dest, results.getDataDump, done);
+		if((options.getDump && !options.dest) || options.dest) {
+			fs.writeFile(options.dest || './data.sql', results.getDataDump, done);
+		}
 	});
 }


### PR DESCRIPTION
In some cases man need to get dump output and post it to server, so file I/O is redundant. I think it's an important feature.