### PR TITLE
SET foreign_key_checks = 0;

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,8 +125,7 @@ module.exports = function(options,done){
 		host: 'localhost',
 		user: 'root',
 		password: '',
-		database: 'test',
-		charset: 'UTF8_GENERAL_CI',
+		database: 'test'
 	};
 
 	var defaultOptions = {
@@ -137,8 +136,9 @@ module.exports = function(options,done){
 		autoIncrement:true,
 		dropTable:false,
 		getDump:false,
-		// dest:'./data.sql',
-		where: null
+		dest:'./data.sql',
+		where: null, 
+		disableForeignKeyChecks: false
 	}
 
 	mysql = mqNode(extend({},defaultConnection,{
@@ -147,7 +147,6 @@ module.exports = function(options,done){
 		password:options.password,
 		database:options.database,
 		port:options.port,
-		charset:options.charset,
 		socketPath:options.socketPath,
 	}));
 
@@ -157,10 +156,11 @@ module.exports = function(options,done){
 	async.auto({
 		getTables:function(callback){
 			if(!options.tables || !options.tables.length){ // if not especifed, get all
-				mysql.query("SHOW TABLES FROM `"+options.database+"`",function(err,data){
+				mysql.query("SHOW TABLES FROM OrdersManager",function(err,data){
 					if(err) return callback(err);
 					var resp = [];
 					for(var i=0;i<data.length;i++) resp.push(data[i]['Tables_in_'+options.database.toLowerCase()]);
+					
 					callback(err,resp);
 				});
 			} else {
@@ -183,7 +183,7 @@ module.exports = function(options,done){
 				var resp = [];
 				for(var i in data){
 					var r = data[i][0]['Create Table']+";";
-
+					if(options.disableForeignKeyChecks) r = "SET foreign_key_checks = 0;\n" + r;
 					if(options.dropTable) r = r.replace(/CREATE TABLE `/, 'DROP TABLE IF EXISTS `' + data[i][0]['Table'] + '`;\nCREATE TABLE `');
 					if(options.ifNotExist) r = r.replace(/CREATE TABLE `/,'CREATE TABLE IF NOT EXISTS `');
 					if(!options.autoIncrement) r = r.replace(/AUTO_INCREMENT=\d+ /g,'');
@@ -227,8 +227,6 @@ module.exports = function(options,done){
 
 		mysql.connection.end();
 		if(options.getDump) return done(err, results.getDataDump);
-		if((options.getDump && !options.dest) || options.dest) {
-			fs.writeFile(options.dest || './data.sql', results.getDataDump, done);
-		}
+		fs.writeFile(options.dest, results.getDataDump, done);
 	});
 }

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = function(options,done){
 	async.auto({
 		getTables:function(callback){
 			if(!options.tables || !options.tables.length){ // if not especifed, get all
-				mysql.query("SHOW TABLES FROM OrdersManager",function(err,data){
+				mysql.query("SHOW TABLES FROM `"+options.database+"`",function(err,data){
 					if(err) return callback(err);
 					var resp = [];
 					for(var i=0;i<data.length;i++) resp.push(data[i]['Tables_in_'+options.database.toLowerCase()]);


### PR DESCRIPTION
I found and solved an issue.
I have a db ordersmanager with two tables: orders and suppliers.
orders has a column, supplierId, wich is a foreign key to the table suppliers. supplierId is indeed the suppliers' primary key.
Now, if I put a supplier with { supplierId: "AAA", name: "Bob" } and then a order { orderId: "OOO", supplierId: "AAA" } it works, but if I put first the order { orderId: "OOO", supplierId: "AAA" }  and then the supplier  { supplierId: "AAA", name: "Bob" }, it outputs an error, because when I put the order, there is no supplier with id AAA yet.
mysqldump does not take care of this, indeed, in my db .sql backup, it first insert the orders and after the suppliers, resulting in an error.
I have modified the module, now there is the option disableForeignKeyChecks, the default value is false but if it is setted to true then SET foreign_key_checks = 0; is added as the first line of the generated .sql backup file. I tested it and it works. I suggest you, if you want to merge this feature, to modify the readme.md too.