### PR TITLE
Updated README with DumpReturn type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,28 @@ const result = await mysqldump({
 ## Result
 The returned result contains the dump property, which is split into schema and data.
 ```TS
-interface DumpResult {
-    dump: {schema: string, data: string};
+export default interface DumpReturn {
+    /**
+     * The result of the dump
+     */
+    dump : {
+        /**
+         * The concatenated SQL schema dump for the entire database.
+         * Null if configured not to dump.
+         */
+        schema : string | null
+        /**
+         * The concatenated SQL data dump for the entire database.
+         * Null if configured not to dump.
+         */
+        data : string | null
+        /**
+         * The concatenated SQL trigger dump for the entire database.
+         * Null if configured not to dump.
+         */
+        trigger : string | null
+    }
+    tables : Table[]
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,14 @@ const result = await mysqldump({
     },
 })
 ```
+## Result
+The returned result contains the dump property, which is split into schema and data.
+```TS
+interface DumpResult {
+    dump: {schema: string, data: string};
+}
 
+```
 
 ## Options
 All the below options are documented in the [typescript declaration file](./dist/mysqldump.d.ts):


### PR DESCRIPTION
I was creating a dump file, and found there was no quick documentation around what 
```TS
const result = await mysqldump({options});
```
returns. I found the definition within the files and have added it to the README file for easier access for those who do not wish to go through src files or who are not super familiar with typescript.