### PR TITLE
support for `table locks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ export interface DataDumpOptions {
 	 */
 	format?: boolean;
 	/**
+	 * Include file headers in output
+	 * Defaults to true.
+	 */
+	verbose ?: boolean
+	/**
+	 * Use a read lock during the data dump (see: https://dev.mysql.com/doc/refman/5.7/en/replication-solutions-backups-read-only.html)
+	 * Defaults to false.
+	 */
+	lockTables ?: boolean
+	/**
 	 * Dump data from views.
 	 * Defaults to false.
 	 */

--- a/src/interfaces/Options.ts
+++ b/src/interfaces/Options.ts
@@ -164,8 +164,14 @@ export interface DataDumpOptions {
     format ?: boolean
     /**
      * Include file headers in output
+     * Defaults to true.
      */
     verbose ?: boolean
+    /**
+     * Use a read lock during the data dump (see: https://dev.mysql.com/doc/refman/5.7/en/replication-solutions-backups-read-only.html)
+     * Defaults to false.
+     */
+    lockTables ?: boolean
     /**
      * Dump data from views.
      * Defaults to false.

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ const defaultOptions : Options = {
         data: {
             format: true,
             verbose: true,
+            lockTables: false,
             includeViewData: false,
             where: {},
             returnFromFunction: false,

--- a/test/e2e/dataDumpOpts.test.ts
+++ b/test/e2e/dataDumpOpts.test.ts
@@ -84,5 +84,75 @@ describe('mysqldump.e2e', () => {
             expect(res.dump.data).toMatch(multiInsertRegex)
             expect(res.dump.data).not.toMatch(singleInsertRegex)
         })
+
+        const verboseHeaderRegex = /DATA DUMP FOR TABLE:/m
+        it('should include table header if verbose is configured', async () => {
+            // ACT
+            const res = await mysqldump({
+                connection: testConfig,
+                dump: {
+                    data: {
+                        maxRowsPerInsertStatement: 50,
+                        format: false,
+                        verbose: true,
+                    },
+                },
+            })
+
+            // ASSERT
+            expect(res.dump.data).toMatch(verboseHeaderRegex)
+        })
+        it('should not include table header if verbose is not configured', async () => {
+            // ACT
+            const res = await mysqldump({
+                connection: testConfig,
+                dump: {
+                    data: {
+                        maxRowsPerInsertStatement: 50,
+                        format: false,
+                        verbose: false,
+                    },
+                },
+            })
+
+            // ASSERT
+            expect(res.dump.data).not.toMatch(verboseHeaderRegex)
+        })
+
+        const lockTableRegex = /DATA DUMP FOR TABLE: (.*) \(locked\)/m
+        it('should lock tables if configured', async () => {
+            // ACT
+            const res = await mysqldump({
+                connection: testConfig,
+                dump: {
+                    data: {
+                        maxRowsPerInsertStatement: 50,
+                        format: false,
+                        verbose: true,
+                        lockTables: true,
+                    },
+                },
+            })
+
+            // ASSERT
+            expect(res.dump.data).toMatch(lockTableRegex)
+        })
+        it('should not lock tables if not configured', async () => {
+            // ACT
+            const res = await mysqldump({
+                connection: testConfig,
+                dump: {
+                    data: {
+                        maxRowsPerInsertStatement: 50,
+                        format: false,
+                        verbose: true,
+                        lockTables: false,
+                    },
+                },
+            })
+
+            // ASSERT
+            expect(res.dump.data).not.toMatch(lockTableRegex)
+        })
     })
 })


### PR DESCRIPTION
Add additional option `lockTables` (defaults to `false`), which allows to lock all tables during the snapshot in order to be able to create a consistent snapshot.

see also: https://dev.mysql.com/doc/refman/5.7/en/replication-solutions-backups-read-only.html

as described here: https://github.com/bradzacher/mysqldump/issues/54