### PR TITLE
keep the table order of the table whitelist

### DIFF
--- a/src/getTables.ts
+++ b/src/getTables.ts
@@ -46,9 +46,9 @@ async function getTables(
             );
         } else {
             // only include the tables from the options that actually exist in the db
-            tables = tables.filter(
-                t => restrictedTables.indexOf(t.name) !== -1,
-            );
+            tables = restrictedTables
+                .map(tableName => actualTables.find(t => t.name === tableName)) // keeping the order of the passed-in whitelist
+                .filter(t => Boolean(t)) as Array<Table>; // filter out non-existing tables
         }
     }
 

--- a/src/getTables.ts
+++ b/src/getTables.ts
@@ -46,9 +46,10 @@ async function getTables(
             );
         } else {
             // only include the tables from the options that actually exist in the db
+            // keeping the order of the passed-in whitelist and filtering out non-existing tables
             tables = restrictedTables
-                .map(tableName => actualTables.find(t => t.name === tableName)) // keeping the order of the passed-in whitelist
-                .filter(t => Boolean(t)) as Array<Table>; // filter out non-existing tables
+                .map(tableName => actualTables.find(t => t.name === tableName))
+                .filter((t): t is Table => t !== undefined);
         }
     }
 


### PR DESCRIPTION
When providing a table whitelist the order of that whitelist should be kept when dumping the tables.

This helps if dumping the database without table locks and having tables with foreign key references into other tables. By carefully defining the order of tables you can still achieve a consistent dump without violating the referential integrity by first dumping the table containing the foreign key, followed by the table which is the target of the reference.