### PR TITLE
#111 #119 Check if file exists before delete (before unlink)

### DIFF
--- a/src/compressFile.ts
+++ b/src/compressFile.ts
@@ -8,7 +8,9 @@ function compressFile(filename: string): Promise<void> {
 
     const deleteFile = (file: string): void => {
         try {
-            fs.unlinkSync(file);
+            if (fs.existsSync(file)) {
+                fs.unlinkSync(file);
+            }
         } catch (_err) {
             /* istanbul ignore next */
         }

--- a/test/e2e/lib.ts
+++ b/test/e2e/lib.ts
@@ -105,7 +105,9 @@ function dumpTest(
         }
 
         // remove the file
-        fs.unlinkSync(filename);
+        if (fs.existsSync(filename)) {
+            fs.unlinkSync(filename);
+        }
 
         // ASSERT
         const memoryLines = [];


### PR DESCRIPTION
Check if the file to delete actually exists before deleting it/before unlinking it.
Closes #111 
Closes #119 