### PR TITLE
feat: add headers and footers variables to returned result

### DIFF
--- a/src/interfaces/DumpReturn.ts
+++ b/src/interfaces/DumpReturn.ts
@@ -6,6 +6,14 @@ interface DumpReturn {
      */
     dump: {
         /**
+         * The list of header variables.
+         */
+        headerVariables?: string;
+        /**
+         * The list of footer variables.
+         */
+        footerVariables?: string;
+        /**
          * The concatenated SQL schema dump for the entire database.
          * Null if configured not to dump.
          */

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,6 +124,8 @@ export default async function main(inputOptions: Options): Promise<DumpReturn> {
         // list the tables
         const res: DumpReturn = {
             dump: {
+                headerVariables: HEADER_VARIABLES,
+                footerVariables: FOOTER_VARIABLES,
                 schema: null,
                 data: null,
                 trigger: null,


### PR DESCRIPTION
Hello everyones,
This PR allows to use the headers and footers that are included in the file from the returned object.
All remarks and advice are of course welcome.
Have a nice review.
This closes #48 